### PR TITLE
feat- jwt 기능의 회원관리 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bin/
 
 ### IntelliJ IDEA ###
 spotify.yml
+application-jwt.yml
 
 .idea
 *.iws

--- a/build.gradle
+++ b/build.gradle
@@ -42,10 +42,14 @@ dependencies {
     implementation 'org.testcontainers:mysql:1.19.0'
     implementation "org.springframework.boot:spring-boot-configuration-processor"
     implementation("org.springframework.boot:spring-boot-starter-validation")
-
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     //spotify
     implementation 'se.michaelthelin.spotify:spotify-web-api-java:9.1.0'
-    implementation 'com.github.thelinmichael:spotify-web-api-java:master-SNAPSHOT'
+    //implementation 'com.github.thelinmichael:spotify-web-api-java:master-SNAPSHOT'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     //swagger

--- a/src/main/java/project/moodipie/config/JWTFilter.java
+++ b/src/main/java/project/moodipie/config/JWTFilter.java
@@ -1,0 +1,55 @@
+package project.moodipie.config;
+
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpHeaders;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class JWTFilter extends OncePerRequestFilter {
+    private final String secretKey;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        final String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        logger.info("Authorization = " + authorization);
+        if(authorization == null || !authorization.startsWith("Bearer ")){
+            logger.error("Authorization 이 없습니다.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authorization.split(" ")[1];
+
+        if(JWTUtil.isExpired(token,secretKey)){
+            logger.error("Token이 만료되었습니다.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String userEmail = JWTUtil.getEmailFromToken(token, secretKey);
+        if (userEmail == null) {
+            logger.error("Token에서 email을 추출할 수 없습니다.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(userEmail, null, List.of(new SimpleGrantedAuthority("USER")));
+        authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/project/moodipie/config/JWTUtil.java
+++ b/src/main/java/project/moodipie/config/JWTUtil.java
@@ -1,0 +1,59 @@
+package project.moodipie.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+    @Value("${jwt.secret}")
+    private String secretKey;
+    private final Long expireMs = 10 * 60 * 1000L; // 10분
+
+    public static String createJwt(String email, long expiredMs, String secretKey) {
+        return Jwts.builder()
+                .claim("email", email)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public static boolean isExpired(String token, String secretKey) {
+        try {
+            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            return false;
+        } catch (ExpiredJwtException e) {
+            return true;
+        }
+    }
+
+    public static String getEmailFromToken(String token, String secretKey) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.get("email", String.class);
+    }
+
+    public static String refresh(String token, String secretKey,Long expiredMs) {
+        if (isExpired(token, secretKey)) {
+            throw new RuntimeException("Token is expired. Please log in again.");
+        }
+        String email = getEmailFromToken(token, secretKey);
+        return createJwt(email, expiredMs, secretKey);
+    }
+
+    public void expire(String token) {
+        System.out.println("Token has been expired: " + token);
+    }
+
+    public String getSecretKey() {return secretKey;}
+    public Long getExpireMs() {return expireMs;}
+}

--- a/src/main/java/project/moodipie/config/WebSecurityConfig.java
+++ b/src/main/java/project/moodipie/config/WebSecurityConfig.java
@@ -1,0 +1,49 @@
+package project.moodipie.config;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import project.moodipie.user.service.UserService;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+    private final UserService userService;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+
+        return httpSecurity
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(requests -> {
+                    requests.requestMatchers("/login", "/signup","/logout").permitAll();
+                    requests.requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs.yaml").permitAll();
+                    requests.requestMatchers("/users","/token").authenticated();
+                    requests.requestMatchers("/api/**").authenticated();
+
+                })
+                .sessionManagement(
+                        sessionManagement ->
+                                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .addFilterBefore(new JWTFilter(secretKey), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+}

--- a/src/main/java/project/moodipie/user/controller/dto/request/CreateUserRequest.java
+++ b/src/main/java/project/moodipie/user/controller/dto/request/CreateUserRequest.java
@@ -6,7 +6,6 @@ import lombok.Setter;
 import project.moodipie.user.entity.User;
 
 @Getter
-@Setter
 public class CreateUserRequest {
     @Schema(description = "이름", example = "홍길동")
     private String username;

--- a/src/main/java/project/moodipie/user/controller/dto/response/UserInfoResponse.java
+++ b/src/main/java/project/moodipie/user/controller/dto/response/UserInfoResponse.java
@@ -9,14 +9,14 @@ import project.moodipie.user.entity.User;
 @Getter
 @Builder
 @AllArgsConstructor
-public class UserResponse {
+public class UserInfoResponse {
     @Schema(description = "이름", example = "홍길동")
     private String username;
     @Schema(description = "프로필 사진", example = "13855")
     private Integer profilePicture;
 
-    public static UserResponse from(User user) {
-        return UserResponse.builder()
+    public static UserInfoResponse from(User user) {
+        return UserInfoResponse.builder()
                 .username(user.getName())
                 .profilePicture(user.getProfileImage())
                 .build();

--- a/src/main/java/project/moodipie/user/controller/dto/response/UserLoginResponse.java
+++ b/src/main/java/project/moodipie/user/controller/dto/response/UserLoginResponse.java
@@ -10,8 +10,11 @@ import lombok.RequiredArgsConstructor;
 public class UserLoginResponse {
     @Schema(description = "메세지", example = "회원가입이 완료되었습니다.")
     private String message;
+    @Schema(description = "토큰", example = "asdjasdiaojsdasdjaisd2132i438rdhi2d393")
+    private String token;
     @Builder
-    public UserLoginResponse(String message) {
+    public UserLoginResponse(String message, String token) {
         this.message = message;
+        this.token = token;
     }
 }

--- a/src/main/java/project/moodipie/user/controller/dto/response/UserServiceResponse.java
+++ b/src/main/java/project/moodipie/user/controller/dto/response/UserServiceResponse.java
@@ -4,15 +4,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @RequiredArgsConstructor
-public class SignUpResponse {
+public class UserServiceResponse {
     @Schema(description = "메세지", example = "회원가입이 완료되었습니다.")
     private String message;
     @Builder
-    public SignUpResponse(String message) {
+    public UserServiceResponse(String message) {
         this.message = message;
     }
 }

--- a/src/main/java/project/moodipie/user/repository/UserRepository.java
+++ b/src/main/java/project/moodipie/user/repository/UserRepository.java
@@ -9,6 +9,4 @@ import project.moodipie.user.entity.User;
 public interface UserRepository extends JpaRepository<User, Long> {
     User findByEmail(String email);
     void deleteByEmail(String email);
-
-    User getReferenceByName(String username);
 }

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -1,0 +1,10 @@
+jwt:
+  secret: 63fba97a41e0d004234234b00a54c732aca36a8a58258e4fcc539ffc5159a7f0a7be78b86efe001c12ba6af6debeb0a89e8ce7e82e75455
+
+  access:
+    expiration: 80
+    header: Authorization
+
+  refresh:
+    expiration: 90
+    header: Authorization-refresh

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,8 @@ spring:
     allow-bean-definition-overriding: true
   config:
     import: spotify.yml
+  profiles:
+    include: jwt
   jpa:
     open-in-view: true
     hibernate:
@@ -26,3 +28,4 @@ logging:
         type:
           descriptor:
             sql: trace
+


### PR DESCRIPTION
1. 세션 -> jwt 로 구현 (이유는 rest의 stateless 유지)
2. 참고 사항 (application-jwt.yml파일을 추가, security config에서 url의 권한 설정, url에 요청시 일부 url은 Header로 Authorization : Bearer [token]필요 )